### PR TITLE
readme: Correctly attribute extension conflict to Perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Before                     | After
 
 ## How do I use it?
 - If you already have the Prolog extension, sadly it needs to be disabled or uninstalled first because it will override this extension.
-- Prolog unfortunately chose to have the same file extension as Perl (`.pl`), and Perl is a built-in language.
+- Perl unfortunately chose to have the same file extension as Prolog (`.pl`), and Perl is a built-in language.
   - so, to make the file show up as Prolog, follow this guide. [guide](https://www.gyanblog.com/vscode/visual-studio-code-associate-file-extensions-language/)
   - basically replace their `"*.module": "php", ` with `"*.pl": "prolog", `
   - (if the changes don't seem to apply, try reloading VS Code)


### PR DESCRIPTION
The old statement didn't sound right to me, so I [found](https://news.ycombinator.com/item?id=34428937) [that](https://www.swi-prolog.org/download/stable/doc/SWI-Prolog-5.10.0.pdf):

> Prolog is older than Perl. Perl usurped the .pl extension. Some are trying to claim it back.

And:

> The documentation for SWI-Prolog 5.10 (2010) even says "Tradition calls for .pl, but conflicts with Perl force the use of another extension on systems where extensions have global meaning, such as MS-Windows. On such systems .pro is the common alternative.

This checks out with Prolog being older than Perl.