### PR TITLE
fix: Detect more modern Prolog file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
                     "prolog"
                 ],
                 "extensions": [
-                    ".pl"
+                    ".pl",
+                    ".pro",
+                    ".prolog"
                 ],
                 "configuration": "./prolog.configuration.json"
             }


### PR DESCRIPTION
These file extensions are used for Prolog. It also is worth considering deleting the `.pl` item entirely, and letting the user set the file extension as shown in the README since Perl is much more common.